### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is to accompany my LED Sunrise Video:
 1. Download the .ino file
 2. Ensure you have the correct libraries download and installed (links at top of the ino file)
 3. Update information in the user configuration section and upload to the NodeMCU
-4. Hook up your NodeMCU, to your RGBW LED strip (default pin is D1 which is GPIO-5)
+4. Hook up your NodeMCU, to your RGBW LED strip (default pin is RX which is GPIO-3)
 5. Send the number of minutes you'd like the sunrise to be spread over to the MQTT topic:
 
 ```c++


### PR DESCRIPTION
Changed default pin from GPIO-5 to GPIO-3. GPIO-5 does NOT work with NodeMCU as configured in the original youtube video tutorial.